### PR TITLE
Publish Kegnet message when user token is authenticated

### DIFF
--- a/kegbot/pycore/common_defs.py
+++ b/kegbot/pycore/common_defs.py
@@ -21,7 +21,7 @@
 ### Drink-related constants
 
 # Don't record teeny drinks
-MIN_VOLUME_TO_RECORD = 10
+MIN_VOLUME_TO_RECORD = 35
 
 # The maximum difference between consecutive meter readings that is considered
 # valid.

--- a/kegbot/pycore/kbevent.py
+++ b/kegbot/pycore/kbevent.py
@@ -132,6 +132,9 @@ class SetRelayOutputEvent(Event):
   output_name = EventField()
   output_mode = EventField()
 
+class UserAuthenticatedEvent(Event):
+  username = EventField()
+  
 class SyncEvent(Event):
   data = EventField()
 

--- a/kegbot/pycore/kegnet.py
+++ b/kegbot/pycore/kegnet.py
@@ -109,6 +109,11 @@ class KegnetClient(object):
     message.token_value = token_value
     message.status = message.TokenState.REMOVED
     return self.send_message(message)
+	  
+  def SendUserAuthenticated(self, username):
+    message = kbevent.UserAuthenticatedEvent()
+    message.username = username
+    return self.send_message(message)
 
   def Listen(self):
     while True:

--- a/kegbot/pycore/manager.py
+++ b/kegbot/pycore/manager.py
@@ -284,6 +284,10 @@ class FlowManager(Manager):
   def _PublishRelayEvent(self, flow, enable=True):
     self._logger.debug('Publishing relay event: flow=%s, enable=%s' % (flow,
         enable))
+			
+    client = kegnet.KegnetClient()
+    client.SendUserAuthenticated(flow.GetUsername())
+		
     tap = self._tap_manager.GetTap(flow.GetMeterName())
     if not tap:
       # Unknown meter; don't attempt to enable any relays for it


### PR DESCRIPTION
When a user token is authenticated, publish an event to the Kegnet. Specifically this is used to notify the web interface a user has been identified via RFID token.