### PR TITLE
Remove repeat events and add token unassigned

### DIFF
--- a/kegbot/pycore/manager.py
+++ b/kegbot/pycore/manager.py
@@ -284,10 +284,7 @@ class FlowManager(Manager):
   def _PublishRelayEvent(self, flow, enable=True):
     self._logger.debug('Publishing relay event: flow=%s, enable=%s' % (flow,
         enable))
-			
-    client = kegnet.KegnetClient()
-    client.SendUserAuthenticated(flow.GetUsername())
-		
+				
     tap = self._tap_manager.GetTap(flow.GetMeterName())
     if not tap:
       # Unknown meter; don't attempt to enable any relays for it
@@ -560,15 +557,20 @@ class AuthenticationManager(Manager):
       username = token.get('username')
     except kbapi.NotFoundError:
       pass
+	  
+	client = kegnet.KegnetClient()  
 
     if not username:
+	  client.SendUserAuthenticated('')
       self._logger.info('Token not assigned: %s' % record)
       return
 
     if not token.enabled:
+	  client.SendUserAuthenticated('')
       self._logger.info('Token disabled: %s' % record)
       return
 
+	client.SendUserAuthenticated(username)  
     max_idle = common_defs.AUTH_DEVICE_MAX_IDLE_SECS.get(record.auth_device)
     if max_idle is None:
       max_idle = common_defs.AUTH_DEVICE_MAX_IDLE_SECS['default']

--- a/kegbot/pycore/manager.py
+++ b/kegbot/pycore/manager.py
@@ -558,19 +558,19 @@ class AuthenticationManager(Manager):
     except kbapi.NotFoundError:
       pass
 	  
-	client = kegnet.KegnetClient()  
+    client = kegnet.KegnetClient()  
 
     if not username:
-	  client.SendUserAuthenticated('')
+      client.SendUserAuthenticated('')
       self._logger.info('Token not assigned: %s' % record)
       return
 
     if not token.enabled:
-	  client.SendUserAuthenticated('')
+      client.SendUserAuthenticated('')
       self._logger.info('Token disabled: %s' % record)
       return
 
-	client.SendUserAuthenticated(username)  
+    client.SendUserAuthenticated(username)  
     max_idle = common_defs.AUTH_DEVICE_MAX_IDLE_SECS.get(record.auth_device)
     if max_idle is None:
       max_idle = common_defs.AUTH_DEVICE_MAX_IDLE_SECS['default']


### PR DESCRIPTION
Updates to the Core logic to publish an event only once for each token event. This also configures the backend to publish events even if a token is not authenticated so that the front-end can notify the user.