### PR TITLE
Resolve issue with processing Relay Activation Events

### DIFF
--- a/kegbot/pycore/kegnet.py
+++ b/kegbot/pycore/kegnet.py
@@ -115,6 +115,9 @@ class KegnetClient(object):
     message.username = username
     return self.send_message(message)
 
+  def SendRelayEvent(self, event):
+    return self.send_message(event)
+
   def Listen(self):
     while True:
       try:

--- a/kegbot/pycore/manager.py
+++ b/kegbot/pycore/manager.py
@@ -77,6 +77,7 @@ class Manager(object):
 
   def _PublishEvent(self, event):
     """Convenience alias for EventHub.PublishEvent"""
+    self._logger.debug('Publishing event %s' % event)
     self._event_hub.PublishEvent(event)
 
 
@@ -285,6 +286,8 @@ class FlowManager(Manager):
     self._logger.debug('Publishing relay event: flow=%s, enable=%s' % (flow,
         enable))
 				
+    client = kegnet.KegnetClient()
+
     tap = self._tap_manager.GetTap(flow.GetMeterName())
     if not tap:
       # Unknown meter; don't attempt to enable any relays for it
@@ -303,6 +306,7 @@ class FlowManager(Manager):
       mode = kbevent.SetRelayOutputEvent.Mode.DISABLED
     ev = kbevent.SetRelayOutputEvent(output_name=relay, output_mode=mode)
     self._PublishEvent(ev)
+    client.SendRelayEvent(ev)
 
   @EventHandler(kbevent.FlowRequest)
   def _HandleFlowRequestEvent(self, event):


### PR DESCRIPTION
Previous updates broke the ability for Kegbot to activate relays connected to the Arduino/Kegboard. This fixes that issue by updating the listener on the Kegboard Daemon and publishing a different event from the Manager App.